### PR TITLE
Updating license in composer.json to MIT License

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Yii2 extension for Mobile-Detect library",
 	"type": "yii2-extension",
 	"keywords": ["yii2","extension","widget","device","detect","mobile","phone","tablet","desktop"],
-	"license": "GNU General Public License v3",
+	"license": "MIT License",
 	"authors": [
 		{
 			"name": "Alexander Nestorov",


### PR DESCRIPTION
Updating license in composer.json to MIT License so that the license on Packagist(GNU Lesser General Public License v3) can be updated to have the same license as the GitHub repo(MIT License).